### PR TITLE
fix(processors): replace en– and em— dashes in EmDashProcessor

### DIFF
--- a/lib/processors/emdash-processor.ts
+++ b/lib/processors/emdash-processor.ts
@@ -2,6 +2,9 @@ import { TextProcessor } from '../interfaces';
 
 export class EmDashProcessor implements TextProcessor {
   process(s: string): string {
-    return s.replace(/ — /g, ', ');
+    return s
+      .replace(/ — /g, ', ')
+      .replace(/ – /g, ', ')
+      .trim();
   }
 }


### PR DESCRIPTION
Previously only the em dash (U+2014) with surrounding spaces was matched.
Add support for the en dash (U+2013) and ensure both are replaced with ", ".
